### PR TITLE
TECH-77 - Publish mongo on nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,6 @@ jobs:
 
       - run: ./Build.ps1
         shell: pwsh
-        # env:
-        #   NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
-          # NUGET_API_KEY: ${{ secrets.GSOFTINC_NUGET_API_KEY }}
+        env:
+          NUGET_SOURCE: ${{ secrets.NUGET_SOURCE }}
+          NUGET_API_KEY: ${{ secrets.GSOFTINC_NUGET_API_KEY }}


### PR DESCRIPTION
Now that the lib is public, we have access to org secrets and can publish to nuget.