### PR TITLE
[TECH-348] Add Azure Application Insights instrumentation

### DIFF
--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/ApplicationInsightsEventSubscriber.cs
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/ApplicationInsightsEventSubscriber.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using GSoft.Extensions.Mongo.Telemetry;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using MongoDB.Driver.Core.Events;
+
+namespace GSoft.Extensions.Mongo.ApplicationInsights;
+
+internal sealed class ApplicationInsightsEventSubscriber : AggregatorEventSubscriber
+{
+    private readonly TelemetryClient _telemetryClient;
+    private readonly MongoClientOptions _options;
+    private readonly ConcurrentDictionary<int, ActivityAwareOperationHolder> _currentOperationsMap;
+
+    public ApplicationInsightsEventSubscriber(TelemetryClient telemetryClient, MongoClientOptions options)
+    {
+        this._telemetryClient = telemetryClient;
+        this._options = options;
+        this._currentOperationsMap = new ConcurrentDictionary<int, ActivityAwareOperationHolder>();
+
+        this.Subscribe<CommandStartedEvent>(this.CommandStartedEventHandler);
+        this.Subscribe<CommandSucceededEvent>(this.CommandSucceededEventHandler);
+        this.Subscribe<CommandFailedEvent>(this.CommandFailedEventHandler);
+    }
+
+    private void CommandStartedEventHandler(CommandStartedEvent evt)
+    {
+        if (this._options.Telemetry.IgnoredCommandNames.Contains(evt.CommandName))
+        {
+            return;
+        }
+
+        var name = evt.GetCollectionName() is { } collectionName
+            ? $"{evt.DatabaseNamespace.DatabaseName}.{collectionName}.{evt.CommandName}"
+            : $"{evt.DatabaseNamespace.DatabaseName}.{evt.CommandName}";
+
+        var operation = this.StartActivityAwareDependencyOperation(name);
+
+        operation.Telemetry.Type = "mongodb";
+
+        operation.Telemetry.Target = evt.ConnectionId?.ServerId?.EndPoint switch
+        {
+            IPEndPoint endPoint => endPoint.Address + ":" + endPoint.Port,
+            DnsEndPoint endPoint => endPoint.Host + ":" + endPoint.Port,
+            _ => "unknown",
+        };
+
+        if (this._options.Telemetry.CaptureCommandText)
+        {
+            operation.Telemetry.Data = evt.Command.ToString();
+        }
+
+        // Originating activity must be captured AFTER that the operation is created
+        // Because ApplicationInsights SDK creates another intermediate Activity
+        var originatingActivity = Activity.Current;
+
+        this._currentOperationsMap.TryAdd(evt.RequestId, new ActivityAwareOperationHolder(operation, originatingActivity));
+    }
+
+    private void CommandSucceededEventHandler(CommandSucceededEvent evt)
+    {
+        if (!this._currentOperationsMap.TryRemove(evt.RequestId, out var operation))
+        {
+            return;
+        }
+
+        using (operation)
+        {
+            operation.Telemetry.Duration = evt.Duration;
+            operation.Telemetry.Success = true;
+        }
+    }
+
+    private void CommandFailedEventHandler(CommandFailedEvent evt)
+    {
+        if (!this._currentOperationsMap.TryRemove(evt.RequestId, out var operation))
+        {
+            return;
+        }
+
+        using (operation)
+        {
+            operation.Telemetry.Duration = evt.Duration;
+            operation.Telemetry.Success = false;
+
+            if (!operation.Telemetry.Properties.ContainsKey("Exception"))
+            {
+                operation.Telemetry.Properties.Add("Exception", evt.Failure.ToString());
+            }
+        }
+    }
+
+    private IOperationHolder<DependencyTelemetry> StartActivityAwareDependencyOperation(string name)
+    {
+        if (Activity.Current is { } activity && TracingHelper.IsMongoActivity(activity))
+        {
+            // When the current activity is our own Mongo activity created in our previous command tracing behavior,
+            // then we use it to initialize the Application Insights operation.
+            // The Application Insights SDK will take care of populating the parent-child relationship
+            // and bridge the gap between our activity, its own internal activity and the AI operation telemetry.
+            // Not doing that could cause some Application Insights AND OpenTelemetry spans to be orphans.
+            var operation = this._telemetryClient.StartOperation<DependencyTelemetry>(activity);
+            operation.Telemetry.Name = name;
+
+            // Remove telemetry copied from our Mongo activity as we already have it in the AI operation
+            foreach (var item in activity.Baggage)
+            {
+                operation.Telemetry.Properties.Remove(item.Key);
+            }
+
+            foreach (var item in activity.Tags)
+            {
+                operation.Telemetry.Properties.Remove(item.Key);
+            }
+
+            return operation;
+        }
+
+        return this._telemetryClient.StartOperation<DependencyTelemetry>(name);
+    }
+
+    private sealed class ActivityAwareOperationHolder : IOperationHolder<DependencyTelemetry>
+    {
+        private readonly IOperationHolder<DependencyTelemetry> _innerOperationHolder;
+        private readonly Activity? _originatingActivity;
+
+        public ActivityAwareOperationHolder(IOperationHolder<DependencyTelemetry> operation, Activity? originatingActivity)
+        {
+            this._innerOperationHolder = operation;
+            this._originatingActivity = originatingActivity;
+        }
+
+        public DependencyTelemetry Telemetry => this._innerOperationHolder.Telemetry;
+
+        public void Dispose()
+        {
+            var currentActivity = Activity.Current;
+
+            if (currentActivity == this._originatingActivity)
+            {
+                this._innerOperationHolder.Dispose();
+                return;
+            }
+
+            try
+            {
+                Activity.Current = this._originatingActivity;
+                this._innerOperationHolder.Dispose();
+            }
+            finally
+            {
+                Activity.Current = currentActivity;
+            }
+        }
+    }
+}

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/ApplicationInsightsEventSubscriberFactory.cs
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/ApplicationInsightsEventSubscriberFactory.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver.Core.Events;
+
+namespace GSoft.Extensions.Mongo.ApplicationInsights;
+
+internal sealed class ApplicationInsightsEventSubscriberFactory : IMongoEventSubscriberFactory
+{
+    private readonly IOptionsMonitor<MongoClientOptions> _optionsMonitor;
+    private readonly TelemetryClient? _telemetryClient;
+
+    public ApplicationInsightsEventSubscriberFactory(IOptionsMonitor<MongoClientOptions> optionsMonitor, TelemetryClient? telemetryClient = null)
+    {
+        this._telemetryClient = telemetryClient;
+        this._optionsMonitor = optionsMonitor;
+    }
+
+    public IEnumerable<IEventSubscriber> CreateEventSubscribers(string clientName)
+    {
+        if (this._telemetryClient != null)
+        {
+            var options = this._optionsMonitor.Get(clientName);
+            yield return new ApplicationInsightsEventSubscriber(this._telemetryClient, options);
+        }
+    }
+}

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/ConfigureMongoClientOptions.cs
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/ConfigureMongoClientOptions.cs
@@ -1,0 +1,32 @@
+﻿using GSoft.Extensions.Mongo.Telemetry;
+using Microsoft.Extensions.Options;
+
+namespace GSoft.Extensions.Mongo.ApplicationInsights;
+
+internal sealed class ConfigureMongoClientOptions : IConfigureNamedOptions<MongoClientOptions>
+{
+    public void Configure(MongoClientOptions options)
+    {
+    }
+
+    public void Configure(string name, MongoClientOptions options)
+    {
+        var existingPostConfigureEventSubscribers = options.PostConfigureEventSubscribers;
+
+        options.PostConfigureEventSubscribers = eventSubscribers =>
+        {
+            var openTelemetryEventSubscriberIdx = eventSubscribers.FindIndex(x => x is CommandTracingEventSubscriber);
+            var appInsightsEventSubscriberIdx = eventSubscribers.FindIndex(x => x is ApplicationInsightsEventSubscriber);
+
+            if (openTelemetryEventSubscriberIdx != -1 && appInsightsEventSubscriberIdx != -1)
+            {
+                // Make sure the Application Insights event subscriber is after the OpenTelemetry event subscriber
+                var appInsightsEventSubscriber = eventSubscribers[appInsightsEventSubscriberIdx];
+                eventSubscribers.RemoveAt(appInsightsEventSubscriberIdx);
+                eventSubscribers.Insert(openTelemetryEventSubscriberIdx + 1, appInsightsEventSubscriber);
+            }
+
+            existingPostConfigureEventSubscribers?.Invoke(eventSubscribers);
+        };
+    }
+}

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/ConfigureMongoClientOptions.cs
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/ConfigureMongoClientOptions.cs
@@ -20,7 +20,11 @@ internal sealed class ConfigureMongoClientOptions : IConfigureNamedOptions<Mongo
 
             if (openTelemetryEventSubscriberIdx != -1 && appInsightsEventSubscriberIdx != -1)
             {
-                // Make sure the Application Insights event subscriber is after the OpenTelemetry event subscriber
+                // Make sure the Application Insights (AI) event subscriber is placed AFTER the OpenTelemetry (OTel) event subscriber.
+                // Both AI and OTel are heavily activity-based (System.Diagnostics.Activity). Having AI's activity created after OTel's activity
+                // ensures the span hierarchy is correct in AI and OTel when using both:
+                // https://github.com/microsoft/ApplicationInsights-dotnet/blob/2.21.0/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs#L368-L383
+                // We did the same for MediatR in this PR: https://github.com/gsoft-inc/gsoft-extensions-mediatr/pull/21
                 var appInsightsEventSubscriber = eventSubscribers[appInsightsEventSubscriberIdx];
                 eventSubscribers.RemoveAt(appInsightsEventSubscriberIdx);
                 eventSubscribers.Insert(openTelemetryEventSubscriberIdx + 1, appInsightsEventSubscriber);

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/GSoft.Extensions.Mongo.ApplicationInsights.csproj
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/GSoft.Extensions.Mongo.ApplicationInsights.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>True</IsPackable>
+    <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <AssemblyTitle>GSoft.Extensions.Mongo.ApplicationInsights</AssemblyTitle>
+    <PackageId>GSoft.Extensions.Mongo.ApplicationInsights</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GSoft.Extensions.Mongo\GSoft.Extensions.Mongo.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Link="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/MongoBuilderExtensions.cs
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/MongoBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace GSoft.Extensions.Mongo.ApplicationInsights;
+
+public static class MongoBuilderExtensions
+{
+    public static MongoBuilder AddApplicationInsights(this MongoBuilder builder)
+    {
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IMongoEventSubscriberFactory, ApplicationInsightsEventSubscriberFactory>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<MongoClientOptions>, ConfigureMongoClientOptions>());
+
+        return builder;
+    }
+}

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/PublicAPI.Shipped.txt
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/PublicAPI.Shipped.txt
@@ -1,0 +1,3 @@
+#nullable enable
+GSoft.Extensions.Mongo.ApplicationInsights.MongoBuilderExtensions
+static GSoft.Extensions.Mongo.ApplicationInsights.MongoBuilderExtensions.AddApplicationInsights(this GSoft.Extensions.Mongo.MongoBuilder! builder) -> GSoft.Extensions.Mongo.MongoBuilder!

--- a/src/GSoft.Extensions.Mongo.ApplicationInsights/PublicAPI.Unshipped.txt
+++ b/src/GSoft.Extensions.Mongo.ApplicationInsights/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GSoft.Extensions.Mongo.Tests/EventSubscriberTests.cs
+++ b/src/GSoft.Extensions.Mongo.Tests/EventSubscriberTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Text;
+using GSoft.Extensions.Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using MongoDB.Driver.Core.Events;
+
+namespace GSoft.Extensions.Mongo.Tests;
+
+public class EventSubscriberTests : BaseIntegrationTest<EventSubscriberTests.EventSubscriberFixture>
+{
+    public EventSubscriberTests(EventSubscriberFixture fixture, ITestOutputHelper testOutputHelper)
+        : base(fixture, testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task EventSubscribers_Are_Executed_In_The_Right_Order()
+    {
+        _ = await this.Services.GetRequiredService<IMongoCollection<DummyDocument>>().FindAsync(Builders<DummyDocument>.Filter.Empty);
+        var actualOutput = this.Services.GetRequiredService<StringBuilder>().ToString();
+        this.Logger.LogInformation("Event subscribers call hierarchy: \r\n{Ouput}", actualOutput);
+
+        const string expectedOutput = @"
+CommandTracingEventSubscriber.CommandStartedEvent(find)
+  ApplicationInsightsEventSubscriber.CommandStartedEvent(find)
+    CommandLoggingEventSubscriber.CommandStartedEvent(find)
+    CommandLoggingEventSubscriber.CommandSucceededEvent(find)
+  ApplicationInsightsEventSubscriber.CommandSucceededEvent(find)
+CommandTracingEventSubscriber.CommandSucceededEvent(find)";
+
+        Assert.Equal(expectedOutput.Trim(), actualOutput.Trim());
+    }
+
+    public class EventSubscriberFixture : MongoFixture
+    {
+        public override IServiceCollection ConfigureServices(IServiceCollection services)
+        {
+            base.ConfigureServices(services);
+
+            var actualOutput = new StringBuilder();
+
+            services.AddSingleton(actualOutput);
+            services.Configure<MongoClientOptions>(options =>
+            {
+                var originalPostConfigureEventSubscribers = options.PostConfigureEventSubscribers;
+
+                options.PostConfigureEventSubscribers = eventSubscribers =>
+                {
+                    originalPostConfigureEventSubscribers?.Invoke(eventSubscribers);
+
+                    for (var i = 0; i < eventSubscribers.Count; i++)
+                    {
+                        eventSubscribers[i] = new StringBuilderOutputEventSubscriber(eventSubscribers[i], actualOutput, i);
+                    }
+                };
+            });
+
+            return services;
+        }
+    }
+
+    private sealed class StringBuilderOutputEventSubscriber : IEventSubscriber
+    {
+        private static readonly object LockObj = new object();
+
+        private readonly IEventSubscriber _eventSubscriber;
+        private readonly StringBuilder _output;
+        private readonly int _indentLevel;
+
+        public StringBuilderOutputEventSubscriber(IEventSubscriber eventSubscriber, StringBuilder output, int indentLevel)
+        {
+            this._eventSubscriber = eventSubscriber;
+            this._output = output;
+            this._indentLevel = indentLevel;
+        }
+
+        public bool TryGetEventHandler<TEvent>(out Action<TEvent> handler)
+        {
+            if (this._eventSubscriber.TryGetEventHandler(out handler))
+            {
+                var originalHandler = handler;
+
+                handler = evt =>
+                {
+                    var indent = new string(' ', this._indentLevel * 2);
+
+                    var commandName = evt switch
+                    {
+                        CommandStartedEvent x => x.CommandName,
+                        CommandSucceededEvent x => x.CommandName,
+                        CommandFailedEvent x => x.CommandName,
+                        _ => string.Empty,
+                    };
+
+                    if (!MongoTelemetryOptions.DefaultIgnoredCommandNames.Contains(commandName))
+                    {
+                        lock (LockObj)
+                        {
+                            this._output.AppendLine($"{indent}{this._eventSubscriber.GetType().Name}.{typeof(TEvent).Name}({commandName})");
+                        }
+                    }
+
+                    originalHandler(evt);
+                };
+            }
+
+            return handler != null;
+        }
+    }
+
+    [MongoCollection("dummy")]
+    private class DummyDocument : MongoDocument
+    {
+    }
+}

--- a/src/GSoft.Extensions.Mongo.Tests/GSoft.Extensions.Mongo.Tests.csproj
+++ b/src/GSoft.Extensions.Mongo.Tests/GSoft.Extensions.Mongo.Tests.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\GSoft.Extensions.Mongo.ApplicationInsights\GSoft.Extensions.Mongo.ApplicationInsights.csproj" />
     <ProjectReference Include="..\GSoft.Extensions.Mongo.Ephemeral\GSoft.Extensions.Mongo.Ephemeral.csproj" />
     <ProjectReference Include="..\GSoft.Extensions.Mongo\GSoft.Extensions.Mongo.csproj" />
   </ItemGroup>

--- a/src/GSoft.Extensions.Mongo.Tests/MongoFixture.cs
+++ b/src/GSoft.Extensions.Mongo.Tests/MongoFixture.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using GSoft.ComponentModel.DataAnnotations;
+using GSoft.Extensions.Mongo.ApplicationInsights;
 using GSoft.Extensions.Mongo.Security;
 using GSoft.Extensions.Xunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using GSoft.Extensions.Mongo.Ephemeral;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace GSoft.Extensions.Mongo.Tests;
 
@@ -16,7 +20,8 @@ public class MongoFixture : BaseIntegrationFixture
         base.ConfigureServices(services);
 
         services.TryAddSingleton<AmbientUserContext>();
-        services.AddMongo(Configure).UseEphemeralRealServer().AddEncryptor<AesMongoValueEncryptor>();
+        services.AddMongo(Configure).AddApplicationInsights().UseEphemeralRealServer().AddEncryptor<AesMongoValueEncryptor>();
+        services.AddSingleton(new TelemetryClient(new TelemetryConfiguration("fake-instrumentation-key", new InMemoryChannel())));
 
         return services;
     }

--- a/src/GSoft.Extensions.Mongo.sln
+++ b/src/GSoft.Extensions.Mongo.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GSoft.Extensions.Mongo.Anal
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GSoft.Extensions.Mongo.Analyzers.Tests", "GSoft.Extensions.Mongo.Analyzers.Tests\GSoft.Extensions.Mongo.Analyzers.Tests.csproj", "{4E098500-7424-457C-9B02-DF36B8157FEB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GSoft.Extensions.Mongo.ApplicationInsights", "GSoft.Extensions.Mongo.ApplicationInsights\GSoft.Extensions.Mongo.ApplicationInsights.csproj", "{C81ED89B-648E-484F-B39D-7EB8EEA47ECE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,5 +57,9 @@ Global
 		{4E098500-7424-457C-9B02-DF36B8157FEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4E098500-7424-457C-9B02-DF36B8157FEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4E098500-7424-457C-9B02-DF36B8157FEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C81ED89B-648E-484F-B39D-7EB8EEA47ECE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C81ED89B-648E-484F-B39D-7EB8EEA47ECE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C81ED89B-648E-484F-B39D-7EB8EEA47ECE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C81ED89B-648E-484F-B39D-7EB8EEA47ECE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/GSoft.Extensions.Mongo/AssemblyProperties.cs
+++ b/src/GSoft.Extensions.Mongo/AssemblyProperties.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("GSoft.Extensions.Mongo.ApplicationInsights")]
 [assembly: InternalsVisibleTo("GSoft.Extensions.Mongo.Tests")]

--- a/src/GSoft.Extensions.Mongo/MongoClientOptions.cs
+++ b/src/GSoft.Extensions.Mongo/MongoClientOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Events;
 
 namespace GSoft.Extensions.Mongo;
 
@@ -27,6 +28,8 @@ public sealed class MongoClientOptions
     public MongoTelemetryOptions Telemetry { get; }
 
     public MongoCommandPerformanceAnalysisOptions CommandPerformanceAnalysis { get; }
+
+    internal Action<List<IEventSubscriber>>? PostConfigureEventSubscribers { get; set; }
 }
 
 public sealed class MongoIndexingOptions

--- a/src/GSoft.Extensions.Mongo/MongoClientOptions.cs
+++ b/src/GSoft.Extensions.Mongo/MongoClientOptions.cs
@@ -48,13 +48,15 @@ public sealed class MongoIndexingOptions
 
 public sealed class MongoTelemetryOptions
 {
+    internal static readonly string[] DefaultIgnoredCommandNames =
+    {
+        // These commands would generate a lot of noise in the instrumentation output.
+        "isMaster", "buildInfo", "saslStart", "saslContinue", "getLastError", "getMore", "listIndexes", "ping",
+    };
+
     public MongoTelemetryOptions()
     {
-        this.IgnoredCommandNames = new HashSet<string>(StringComparer.Ordinal)
-        {
-            // Inspired from Officevibe's ignored command names list
-            "isMaster", "buildInfo", "saslStart", "saslContinue", "getLastError", "getMore", "listIndexes", "ping",
-        };
+        this.IgnoredCommandNames = new HashSet<string>(DefaultIgnoredCommandNames, StringComparer.Ordinal);
     }
 
     public bool CaptureCommandText { get; set; }

--- a/src/GSoft.Extensions.Mongo/MongoClientProvider.cs
+++ b/src/GSoft.Extensions.Mongo/MongoClientProvider.cs
@@ -67,7 +67,8 @@ internal sealed class MongoClientProvider : IMongoClientProvider, IDisposable
         }
 
         var eventSubscriberFactories = this._serviceProvider.GetServices<IMongoEventSubscriberFactory>();
-        var eventSubscribers = eventSubscriberFactories.SelectMany(x => x.CreateEventSubscribers(clientName)).ToArray();
+        var eventSubscribers = eventSubscriberFactories.SelectMany(x => x.CreateEventSubscribers(clientName)).ToList();
+        options.PostConfigureEventSubscribers?.Invoke(eventSubscribers);
 
         this._disposableDependencies.AddRange(eventSubscribers.OfType<IDisposable>());
 

--- a/src/GSoft.Extensions.Mongo/MongoClientProvider.cs
+++ b/src/GSoft.Extensions.Mongo/MongoClientProvider.cs
@@ -80,11 +80,7 @@ internal sealed class MongoClientProvider : IMongoClientProvider, IDisposable
         settings.ClusterConfigurator = builder =>
         {
             userDefinedClusterConfiguration?.Invoke(builder);
-
-            foreach (var eventSubscriber in eventSubscribers)
-            {
-                builder.Subscribe(eventSubscriber);
-            }
+            builder.Subscribe(new OrderedAggregatorEventSubscriber(eventSubscribers));
         };
 
         return new MongoClient(settings);

--- a/src/GSoft.Extensions.Mongo/MongoEventSubscriberFactory.cs
+++ b/src/GSoft.Extensions.Mongo/MongoEventSubscriberFactory.cs
@@ -23,11 +23,11 @@ internal sealed class MongoEventSubscriberFactory : IMongoEventSubscriberFactory
     {
         var options = this._optionsMonitor.Get(clientName);
 
-        // Command logging
-        yield return new CommandLoggingEventSubscriber(options, this._loggerFactory);
-
         // Command distributed tracing (Open Telemetry)
         yield return new CommandTracingEventSubscriber(options);
+
+        // Command logging
+        yield return new CommandLoggingEventSubscriber(options, this._loggerFactory);
 
         // Command performance analysis
         if (options.CommandPerformanceAnalysis.IsPerformanceAnalysisEnabled)

--- a/src/GSoft.Extensions.Mongo/OrderedAggregatorEventSubscriber.cs
+++ b/src/GSoft.Extensions.Mongo/OrderedAggregatorEventSubscriber.cs
@@ -1,0 +1,109 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using MongoDB.Driver.Core.Events;
+
+namespace GSoft.Extensions.Mongo;
+
+/// <summary>
+/// Aggregate event subscriber that ensures that "finishing" event handlers are executed
+/// in the reverse order than their "starting" event handlers counterparts.
+/// <code>
+/// Given the following example of four event subscribers that handle both command "started" and command "succeeded" events:
+/// - OpenTelemetry, ApplicationInsights, Logging and UserDefined
+///
+/// By defaut the order of execution of the event handlers would be:
+///
+/// 1. OpenTelemetry.CommandStarted
+///   2. ApplicationInsights.CommandStarted
+///     3. Logging.CommandStarted
+///       4. UserDefined.CommandStarted
+/// 1. OpenTelemetry.CommandSucceeded
+///   2. ApplicationInsights.CommandSucceeded
+///     3. Logging.CommandSucceeded
+///       4. UserDefined.CommandSucceeded
+///
+/// This is incorrect! We want begin/end event handlers to act as nested "middlewares", especially when an event subscriber depends on inner ones.
+/// This class makes sure that the order of execution is:
+///
+/// 1. OpenTelemetry.CommandStarted
+///   2. ApplicationInsights.CommandStarted
+///     3. Logging.CommandStarted
+///       4. UserDefined.CommandStarted
+///       4. UserDefined.CommandSucceeded
+///     3. Logging.CommandSucceeded
+///   2. ApplicationInsights.CommandSucceeded
+/// 1. OpenTelemetry.CommandSucceeded
+///
+/// In this example, the benefits are:
+///   - Any exception or third-party interaction inside user defined ended event handlers will be instrumented by our event handlers.
+///   - The recorded command ended log will be part of the application insights operation and open telemetry activity as events.
+///   - The application insights operation won't be discarded, because its parent open telemetry activity will still be active.
+///   - The open telemetry activity is stopped after every other event handler has been executed.
+/// </code>
+/// </summary>
+internal sealed class OrderedAggregatorEventSubscriber : IEventSubscriber
+{
+    // The list of "finishing" events that have a "starting" counterpart.
+    // See: https://mongodb.github.io/mongo-csharp-driver/2.9/apidocs/html/N_MongoDB_Driver_Core_Events.htm
+    private static readonly HashSet<Type> FinishingEventTypes = new HashSet<Type>
+    {
+        typeof(CommandSucceededEvent), // CommandStartedEvent
+        typeof(CommandFailedEvent), // CommandStartedEvent
+        typeof(ClusterAddedServerEvent), // ClusterAddingServerEvent
+        typeof(ClusterClosedEvent), // ClusterClosingEvent
+        typeof(ClusterOpenedEvent), // ClusterOpeningEvent
+        typeof(ClusterRemovedServerEvent), // ClusterRemovingServerEvent
+        typeof(ClusterSelectedServerEvent), // ClusterSelectingServerEvent
+        typeof(ClusterSelectingServerFailedEvent), // ClusterSelectingServerEvent
+        typeof(ConnectionClosedEvent), // ConnectionClosingEvent
+        typeof(ConnectionOpenedEvent), // ConnectionOpeningEvent
+        typeof(ConnectionOpeningFailedEvent), // ConnectionOpeningEvent
+        typeof(ConnectionPoolAddedConnectionEvent), // ConnectionPoolAddingConnectionEvent
+        typeof(ConnectionPoolCheckedInConnectionEvent), // ConnectionPoolCheckingInConnectionEvent
+        typeof(ConnectionPoolCheckedOutConnectionEvent), // ConnectionPoolCheckingOutConnectionEvent
+        typeof(ConnectionPoolCheckingOutConnectionFailedEvent), // ConnectionPoolCheckingOutConnectionEvent
+        typeof(ConnectionPoolClosedEvent), // ConnectionPoolClosingEvent
+        typeof(ConnectionPoolOpenedEvent), // ConnectionPoolOpeningEvent
+        typeof(ConnectionPoolRemovedConnectionEvent), // ConnectionPoolRemovingConnectionEvent
+        typeof(ConnectionReceivedMessageEvent), // ConnectionReceivingMessageEvent
+        typeof(ConnectionReceivingMessageFailedEvent), // ConnectionReceivingMessageEvent
+        typeof(ConnectionSentMessagesEvent), // ConnectionSendingMessagesEvent
+        typeof(ConnectionSendingMessagesFailedEvent), // ConnectionSendingMessagesEvent
+        typeof(ServerClosedEvent), // ServerClosingEvent
+        typeof(ServerHeartbeatSucceededEvent), // ServerHeartbeatStartedEvent
+        typeof(ServerHeartbeatFailedEvent), // ServerHeartbeatStartedEvent
+        typeof(ServerOpenedEvent), // ServerOpeningEvent
+    };
+
+    private readonly IEventSubscriber[] _subscribers;
+
+    public OrderedAggregatorEventSubscriber(IEnumerable<IEventSubscriber> subscribers)
+    {
+        this._subscribers = subscribers.ToArray();
+    }
+
+    public bool TryGetEventHandler<TEvent>([MaybeNullWhen(false)] out Action<TEvent> handler)
+    {
+        handler = this.GetOrderedHandlers<TEvent>();
+        return handler != null;
+    }
+
+    private Action<TEvent>? GetOrderedHandlers<TEvent>()
+    {
+        // MongoDB C# driver calls this method only once per event type and caches it internally,
+        // so there's no need to overly optimize this process or cache the result.
+        var subscribers = FinishingEventTypes.Contains(typeof(TEvent)) ? this._subscribers.Reverse() : this._subscribers;
+
+        Action<TEvent>? handler = null;
+        return subscribers.Aggregate(handler, ChainHandler);
+    }
+
+    private static Action<TEvent>? ChainHandler<TEvent>(Action<TEvent>? handler, IEventSubscriber subscriber)
+    {
+        if (subscriber.TryGetEventHandler<TEvent>(out var handlerLink))
+        {
+            return handler == null ? handlerLink : handler + handlerLink;
+        }
+
+        return handler;
+    }
+}

--- a/src/GSoft.Extensions.Mongo/Telemetry/CommandLoggingEventSubscriber.cs
+++ b/src/GSoft.Extensions.Mongo/Telemetry/CommandLoggingEventSubscriber.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using MongoDB.Driver.Core.Events;
 
 namespace GSoft.Extensions.Mongo.Telemetry;
@@ -7,11 +9,13 @@ internal sealed class CommandLoggingEventSubscriber : AggregatorEventSubscriber
 {
     private readonly MongoClientOptions _options;
     private readonly ILogger<CommandLoggingEventSubscriber> _logger;
+    private readonly ConcurrentDictionary<int, Activity?> _currentActivitiesMap;
 
     public CommandLoggingEventSubscriber(MongoClientOptions options, ILoggerFactory loggerFactory)
     {
         this._options = options;
         this._logger = loggerFactory.CreateLogger<CommandLoggingEventSubscriber>();
+        this._currentActivitiesMap = new ConcurrentDictionary<int, Activity?>();
 
         this.Subscribe<CommandStartedEvent>(this.CommandStartedEventHandler);
         this.Subscribe<CommandSucceededEvent>(this.CommandSucceededEventHandler);
@@ -33,21 +37,32 @@ internal sealed class CommandLoggingEventSubscriber : AggregatorEventSubscriber
         {
             this._logger.CommandStartedNonSensitive(evt.CommandName, evt.RequestId);
         }
+
+        this._currentActivitiesMap.TryAdd(evt.RequestId, Activity.Current);
     }
 
     private void CommandSucceededEventHandler(CommandSucceededEvent evt)
     {
-        if (!this._options.Telemetry.IgnoredCommandNames.Contains(evt.CommandName))
+        if (this._currentActivitiesMap.TryRemove(evt.RequestId, out var originatingActivity))
         {
-            this._logger.CommandSucceeded(evt.CommandName, evt.RequestId, evt.Duration.TotalSeconds);
+            TracingHelper.WithTemporaryCurrentActivity(originatingActivity, evt, this._logger, static (logger, evt) =>
+            {
+                logger.CommandSucceeded(evt.CommandName, evt.RequestId, evt.Duration.TotalSeconds);
+            });
         }
     }
 
     private void CommandFailedEventHandler(CommandFailedEvent evt)
     {
-        // Manually-cancelled MongoDB commands should not be logged as warnings.
-        // The OperationCanceledException will eventually appear in the logs if not handled.
-        var logLevel = evt.Failure is OperationCanceledException ? LogLevel.Debug : LogLevel.Warning;
-        this._logger.CommandFailed(logLevel, evt.Failure, evt.CommandName, evt.RequestId, evt.Duration.TotalSeconds);
+        if (this._currentActivitiesMap.TryRemove(evt.RequestId, out var originatingActivity))
+        {
+            TracingHelper.WithTemporaryCurrentActivity(originatingActivity, evt, this._logger, static (logger, evt) =>
+            {
+                // Manually-cancelled MongoDB commands should not be logged as warnings.
+                // The OperationCanceledException will eventually appear in the logs if not handled.
+                var logLevel = evt.Failure is OperationCanceledException ? LogLevel.Debug : LogLevel.Warning;
+                logger.CommandFailed(logLevel, evt.Failure, evt.CommandName, evt.RequestId, evt.Duration.TotalSeconds);
+            });
+        }
     }
 }

--- a/src/GSoft.Extensions.Mongo/Telemetry/TracingHelper.cs
+++ b/src/GSoft.Extensions.Mongo/Telemetry/TracingHelper.cs
@@ -1,0 +1,47 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace GSoft.Extensions.Mongo.Telemetry;
+
+internal static class TracingHelper
+{
+    private const string ActivityName = "MongoDB.Driver.Core.Events.Command";
+
+    private static readonly AssemblyName AssemblyName = typeof(CommandTracingEventSubscriber).Assembly.GetName();
+    private static readonly string ActivitySourceName = AssemblyName.Name!;
+    private static readonly Version Version = AssemblyName.Version!;
+    private static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+
+    [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument", Justification = "We want a specific activity name, not the caller method name")]
+    public static Activity? StartActivity()
+    {
+        return ActivitySource.StartActivity(ActivityName, ActivityKind.Client);
+    }
+
+    public static bool IsMongoActivity(Activity activity) => ReferenceEquals(ActivitySource, activity.Source);
+
+    // Seems like MongoDB async commands are not sticking to the Activity.Current flow and we need this workaround:
+    // https://github.com/jbogard/MongoDB.Driver.Core.Extensions.DiagnosticSources/pull/5
+    public static void WithTemporaryCurrentActivity<TEvent, TDep>(Activity? newTemporaryActivity, TEvent evt, TDep dependency, Action<TDep, TEvent> action)
+        where TEvent : struct
+    {
+        var existingActivity = Activity.Current;
+
+        if (existingActivity == newTemporaryActivity)
+        {
+            action(dependency, evt);
+            return;
+        }
+
+        try
+        {
+            Activity.Current = newTemporaryActivity;
+            action(dependency, evt);
+        }
+        finally
+        {
+            Activity.Current = existingActivity;
+        }
+    }
+}


### PR DESCRIPTION
![image](https://github.com/gsoft-inc/gsoft-extensions-mongo/assets/14242083/b9068e7a-f6ae-4fc5-a409-4a2b0e174482)

Spans are hierarchically correct, and still works well with OpenTelemetry (using both at the same time):

![image](https://github.com/gsoft-inc/gsoft-extensions-mongo/assets/14242083/0fed9a3d-223d-44a5-8a1d-7430c0c73902)

Span events (logs) are correct too, attached to the right span
